### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include DESCRIPTION
 include CHANGELOG.txt
 include README.rst
+include requirements.txt
 graft openinghours
 global-exclude *.orig *.pyc *.log *.swp
 prune openinghours/tests/coverage


### PR DESCRIPTION
Could this fix "pip3 install django-openinghours" error.

$[...] pip3 install django-openinghours
Collecting django-openinghours
  Using cached django-openinghours-0.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/.../pip-build-.../django-openinghours/setup.py", line 18, in <module>
        install_requires=open('requirements.txt').read().split(),
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'