### PR TITLE
Fixing pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     url="https://github.com/arteria/django-openinghours",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=open('requirements.txt').read().split(),
+    install_requires=['django', 'django-threadlocals', 'django-compat'],
 )


### PR DESCRIPTION
Updating the manifest didn't solve the installation problem.
This solution is not DRY, but better be safe as I can't easily test this myself.

More information:
http://stackoverflow.com/questions/14399534/how-can-i-reference-requirements-txt-for-the-install-requires-kwarg-in-setuptool

Error in question:

$.. pip3 install django-openinghours
Collecting django-openinghours
  Using cached django-openinghours-0.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/4m/q0mv284n1_qgm7ctvkrmgn4c0000gp/T/pip-build-osj2dtv8/django-openinghours/setup.py", line 18, in <module>
        install_requires=open('requirements.txt').read().split(),
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
