### PR TITLE
make company model swappable

### DIFF
--- a/openinghours/migrations/0001_initial.py
+++ b/openinghours/migrations/0001_initial.py
@@ -4,9 +4,10 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from openinghours.app_settings import PREMISES_MODEL
 
-initial_operations = []
-if PREMISES_MODEL == 'openinghours.Company':
-    initial_operations = [
+
+class Migration(migrations.Migration):
+    dependencies = []
+    operations = [
         migrations.CreateModel(
             name='Company',
             fields=[
@@ -16,15 +17,11 @@ if PREMISES_MODEL == 'openinghours.Company':
                 ('logo', models.FileField(null=True, upload_to=b'logo', blank=True)),
             ],
             options={
+                'swappable': 'OPENINGHOURS_PREMISES_MODEL',
                 'verbose_name': 'Company',
                 'verbose_name_plural': 'Companies',
             },
         ),
-    ]
-
-class Migration(migrations.Migration):
-    dependencies = []
-    operations = initial_operations + [
         migrations.CreateModel(
             name='ClosingRules',
             fields=[

--- a/openinghours/models.py
+++ b/openinghours/models.py
@@ -26,6 +26,7 @@ class Company(models.Model):
     class Meta:
         verbose_name = _('Company')
         verbose_name_plural = _('Companies')
+        swappable = 'OPENINGHOURS_PREMISES_MODEL'
 
     name = models.CharField(_('Name'), max_length=100)
     slug = models.SlugField(_('Slug'), unique=True)


### PR DESCRIPTION
Company model should be swappable. This should fix:
#25 #28 

Also when custom model is used TestRunner is unable to serialize data for openninghours.Company:
```
    return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: relation "openinghours_company" does not exist
LINE 1: ...mpany"."slug", "openinghours_company"."logo" FROM "openingho...

```

This MR should fix this too