### PR TITLE
update setup.py to be compatible on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import openinghours as app
 setup(
     name="django-openinghours",
     version=app.__version__,
-    description=open('DESCRIPTION', encoding='utf-8').read(),
-    long_description=open('README.rst', encoding='utf-8').read(),
+    description=open('DESCRIPTION', 'rb').read(),
+    long_description=open('README.rst', 'rb').read().decode('utf-8'),
     license='The MIT License',
     platforms=['OS Independent'],
     keywords='django, app, openinghours, shop, store',

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import openinghours as app
 setup(
     name="django-openinghours",
     version=app.__version__,
-    description=open('DESCRIPTION').read(),
-    long_description=open('README.rst').read(),
+    description=open('DESCRIPTION', encoding='utf-8').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
     license='The MIT License',
     platforms=['OS Independent'],
     keywords='django, app, openinghours, shop, store',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import openinghours as app
 setup(
     name="django-openinghours",
     version=app.__version__,
-    description=open('DESCRIPTION', 'rb').read(),
+    description=open('DESCRIPTION', 'rb').read().decode('utf-8'),
     long_description=open('README.rst', 'rb').read().decode('utf-8'),
     license='The MIT License',
     platforms=['OS Independent'],


### PR DESCRIPTION
On windows 10, with python 3.6, doing a pip install fails as it does not default to a utf-8 encoding when trying to read in a file.

the source of this fix is from this link: https://stackoverflow.com/questions/49640513/unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-position-x-charac

I'm developing a site using your package, and I couldn't install it on my development machine.